### PR TITLE
ES6 webpack import support

### DIFF
--- a/src/taggle.js
+++ b/src/taggle.js
@@ -8,24 +8,16 @@
 
 // @todo remove bower from next major version
 
-(function(root, factory) {
+(function(global, factory) {
     'use strict';
     var libName = 'Taggle';
 
     /* global define, module */
-    if (typeof define === 'function' && define.amd) {
-        define([], function() {
-            var module = factory();
-            root[libName] = module;
-            return module;
-        });
-    }
-    else if (typeof module === 'object' && module.exports) {
-        module.exports = root[libName] = factory();
-    }
-    else {
-        root[libName] = factory();
-    }
+    typeof exports === 'object' && typeof module !== 'undefined' 
+        ? module.exports = factory() 
+        : typeof define === 'function' && define.amd 
+        ? define(factory) 
+        : global[libName] = factory()
 }(this, function() {
     'use strict';
     /////////////////////


### PR DESCRIPTION
root/global is undefined in prior version when importing taggle w/ ES6 syntax in a webpack build env.

I'm not familiar with the amd define block, but this change works with our webpack ES6 import build process.